### PR TITLE
Update Firebase Crashlytics to 17.4.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,7 +34,7 @@ android {
     defaultConfig {
         applicationId "richard.chard.lu.android.areamapper"
         signingConfig signingConfigs.release
-        minSdkVersion 14
+        minSdkVersion 16
         targetSdkVersion 27
         versionCode 5
         versionName "5.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-location:16.0.0'
     implementation 'com.google.maps.android:android-maps-utils:0.3.4'
     implementation 'com.google.firebase:firebase-core:16.0.5'
-    implementation 'com.crashlytics.sdk.android:crashlytics:2.9.6'
+    implementation 'com.google.firebase:firebase-crashlytics:17.4.1'
 }
 
 afterEvaluate {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,6 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 
 apply plugin: 'com.android.application'
-apply plugin: 'io.fabric'
 
 ext {
     // Obtained from ~/.gradle/gradle.properties on build server (mobile agent), or your local

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,9 @@ buildscript {
         // in the individual module build.gradle files
         classpath 'com.google.gms:google-services:4.2.0'
         classpath 'io.fabric.tools:gradle:1.26.1'
+
+        // Add the Crashlytics Gradle plugin
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.5.2'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,17 +4,14 @@ buildscript {
     repositories {
         jcenter()
         google()
-        maven {
-            url 'https://maven.fabric.io/public'
-        }
     }
+
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
         classpath 'com.google.gms:google-services:4.2.0'
-        classpath 'io.fabric.tools:gradle:1.26.1'
 
         // Add the Crashlytics Gradle plugin
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.5.2'

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
This PR removes the deprecated SDK Fabric and introduces the Crashlytics Gradle Plugin.

Note: Minimum Android SDK was bumped to version 16 as required by Firebase Crashlytics to 17.4.1.