### PR TITLE
Migrate to Firebase Crashlytics version 17.4.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,7 +34,7 @@ android {
     defaultConfig {
         applicationId "richard.chard.lu.android.areamapper"
         signingConfig signingConfigs.release
-        minSdkVersion 14
+        minSdkVersion 16
         targetSdkVersion 27
         versionCode 5
         versionName "5.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-location:16.0.0'
     implementation 'com.google.maps.android:android-maps-utils:0.3.4'
     implementation 'com.google.firebase:firebase-core:16.0.5'
-    implementation 'com.crashlytics.sdk.android:crashlytics:2.9.6'
+    implementation 'com.google.firebase:firebase-crashlytics:17.4.1'
 }
 
 afterEvaluate {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 
 apply plugin: 'com.android.application'
+apply plugin: 'com.google.firebase.crashlytics'
 
 ext {
     // Obtained from ~/.gradle/gradle.properties on build server (mobile agent), or your local

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,6 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 
 apply plugin: 'com.android.application'
-apply plugin: 'io.fabric'
 
 ext {
     // Obtained from ~/.gradle/gradle.properties on build server (mobile agent), or your local

--- a/app/templates/google-services.json
+++ b/app/templates/google-services.json
@@ -21,16 +21,7 @@
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyDDh8PWdeUSvv55vUQsRIO_t23GUukqJAw"
-        },
-        {
-          "current_key": "AIzaSyDpLXffDgRluouKQ54Z4hSPqRORBbTwjcY"
-        },
-        {
-          "current_key": "AIzaSyDx6neJf_c4NA_17mNZ9e_aD4-SGJyig8c"
-        },
-        {
-          "current_key": "AIzaSyC29AadllbS3sZ3Jq_72Ae-wQaN8ykEx3g"
+          "current_key": "@apiKey@"
         }
       ],
       "services": {
@@ -60,16 +51,7 @@
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyDDh8PWdeUSvv55vUQsRIO_t23GUukqJAw"
-        },
-        {
-          "current_key": "AIzaSyDpLXffDgRluouKQ54Z4hSPqRORBbTwjcY"
-        },
-        {
-          "current_key": "AIzaSyDx6neJf_c4NA_17mNZ9e_aD4-SGJyig8c"
-        },
-        {
-          "current_key": "AIzaSyC29AadllbS3sZ3Jq_72Ae-wQaN8ykEx3g"
+          "current_key": "@apiKey@"
         }
       ],
       "services": {
@@ -98,16 +80,7 @@
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyDDh8PWdeUSvv55vUQsRIO_t23GUukqJAw"
-        },
-        {
-          "current_key": "AIzaSyDpLXffDgRluouKQ54Z4hSPqRORBbTwjcY"
-        },
-        {
-          "current_key": "AIzaSyDx6neJf_c4NA_17mNZ9e_aD4-SGJyig8c"
-        },
-        {
-          "current_key": "AIzaSyC29AadllbS3sZ3Jq_72Ae-wQaN8ykEx3g"
+          "current_key": "@apiKey@"
         }
       ],
       "services": {
@@ -137,16 +110,7 @@
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyDDh8PWdeUSvv55vUQsRIO_t23GUukqJAw"
-        },
-        {
-          "current_key": "AIzaSyDpLXffDgRluouKQ54Z4hSPqRORBbTwjcY"
-        },
-        {
-          "current_key": "AIzaSyDx6neJf_c4NA_17mNZ9e_aD4-SGJyig8c"
-        },
-        {
-          "current_key": "AIzaSyC29AadllbS3sZ3Jq_72Ae-wQaN8ykEx3g"
+          "current_key": "@apiKey@"
         }
       ],
       "services": {
@@ -176,16 +140,7 @@
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyDDh8PWdeUSvv55vUQsRIO_t23GUukqJAw"
-        },
-        {
-          "current_key": "AIzaSyDpLXffDgRluouKQ54Z4hSPqRORBbTwjcY"
-        },
-        {
-          "current_key": "AIzaSyDx6neJf_c4NA_17mNZ9e_aD4-SGJyig8c"
-        },
-        {
-          "current_key": "AIzaSyC29AadllbS3sZ3Jq_72Ae-wQaN8ykEx3g"
+          "current_key": "@apiKey@"
         }
       ],
       "services": {
@@ -214,16 +169,7 @@
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyDDh8PWdeUSvv55vUQsRIO_t23GUukqJAw"
-        },
-        {
-          "current_key": "AIzaSyDpLXffDgRluouKQ54Z4hSPqRORBbTwjcY"
-        },
-        {
-          "current_key": "AIzaSyDx6neJf_c4NA_17mNZ9e_aD4-SGJyig8c"
-        },
-        {
-          "current_key": "AIzaSyC29AadllbS3sZ3Jq_72Ae-wQaN8ykEx3g"
+          "current_key": "@apiKey@"
         }
       ],
       "services": {
@@ -252,16 +198,7 @@
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyDDh8PWdeUSvv55vUQsRIO_t23GUukqJAw"
-        },
-        {
-          "current_key": "AIzaSyDpLXffDgRluouKQ54Z4hSPqRORBbTwjcY"
-        },
-        {
-          "current_key": "AIzaSyDx6neJf_c4NA_17mNZ9e_aD4-SGJyig8c"
-        },
-        {
-          "current_key": "AIzaSyC29AadllbS3sZ3Jq_72Ae-wQaN8ykEx3g"
+          "current_key": "@apiKey@"
         }
       ],
       "services": {
@@ -290,16 +227,7 @@
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyDDh8PWdeUSvv55vUQsRIO_t23GUukqJAw"
-        },
-        {
-          "current_key": "AIzaSyDpLXffDgRluouKQ54Z4hSPqRORBbTwjcY"
-        },
-        {
-          "current_key": "AIzaSyDx6neJf_c4NA_17mNZ9e_aD4-SGJyig8c"
-        },
-        {
-          "current_key": "AIzaSyC29AadllbS3sZ3Jq_72Ae-wQaN8ykEx3g"
+          "current_key": "@apiKey@"
         }
       ],
       "services": {
@@ -328,16 +256,7 @@
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyDDh8PWdeUSvv55vUQsRIO_t23GUukqJAw"
-        },
-        {
-          "current_key": "AIzaSyDpLXffDgRluouKQ54Z4hSPqRORBbTwjcY"
-        },
-        {
-          "current_key": "AIzaSyDx6neJf_c4NA_17mNZ9e_aD4-SGJyig8c"
-        },
-        {
-          "current_key": "AIzaSyC29AadllbS3sZ3Jq_72Ae-wQaN8ykEx3g"
+          "current_key": "@apiKey@"
         }
       ],
       "services": {
@@ -366,16 +285,7 @@
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyDDh8PWdeUSvv55vUQsRIO_t23GUukqJAw"
-        },
-        {
-          "current_key": "AIzaSyDpLXffDgRluouKQ54Z4hSPqRORBbTwjcY"
-        },
-        {
-          "current_key": "AIzaSyDx6neJf_c4NA_17mNZ9e_aD4-SGJyig8c"
-        },
-        {
-          "current_key": "AIzaSyC29AadllbS3sZ3Jq_72Ae-wQaN8ykEx3g"
+          "current_key": "@apiKey@"
         }
       ],
       "services": {

--- a/app/templates/google-services.json
+++ b/app/templates/google-services.json
@@ -1,52 +1,391 @@
 {
   "project_info": {
-    "project_number": "363835147397",
-    "firebase_url": "https://durable-jet-88016.firebaseio.com",
-    "project_id": "durable-jet-88016",
-    "storage_bucket": "durable-jet-88016.appspot.com"
+    "project_number": "768065119425",
+    "firebase_url": "https://commcare-a57e4.firebaseio.com",
+    "project_id": "commcare-a57e4",
+    "storage_bucket": "commcare-a57e4.appspot.com"
   },
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:363835147397:android:4aabcacd2e2d50cb",
+        "mobilesdk_app_id": "1:768065119425:android:5d470198e0a973a5",
+        "android_client_info": {
+          "package_name": "org.commcare.consumerapps.clinicalscales"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "768065119425-hg10t0osvjqrt6pne3toaobabn5gobqs.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDDh8PWdeUSvv55vUQsRIO_t23GUukqJAw"
+        },
+        {
+          "current_key": "AIzaSyDpLXffDgRluouKQ54Z4hSPqRORBbTwjcY"
+        },
+        {
+          "current_key": "AIzaSyDx6neJf_c4NA_17mNZ9e_aD4-SGJyig8c"
+        },
+        {
+          "current_key": "AIzaSyC29AadllbS3sZ3Jq_72Ae-wQaN8ykEx3g"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "768065119425-05thotts3f4ujdcscoaeheebpia8ag9m.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      },
+      "admob_app_id": "ca-app-pub-8038725004530429~5040587593"
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:768065119425:android:455113c70d7e361f",
+        "android_client_info": {
+          "package_name": "org.commcare.consumerapps.germygameshindi"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "768065119425-hg10t0osvjqrt6pne3toaobabn5gobqs.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDDh8PWdeUSvv55vUQsRIO_t23GUukqJAw"
+        },
+        {
+          "current_key": "AIzaSyDpLXffDgRluouKQ54Z4hSPqRORBbTwjcY"
+        },
+        {
+          "current_key": "AIzaSyDx6neJf_c4NA_17mNZ9e_aD4-SGJyig8c"
+        },
+        {
+          "current_key": "AIzaSyC29AadllbS3sZ3Jq_72Ae-wQaN8ykEx3g"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "768065119425-05thotts3f4ujdcscoaeheebpia8ag9m.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:768065119425:android:c3c3abf2cc22a9d8",
+        "android_client_info": {
+          "package_name": "org.commcare.consumerapps.savingmoney"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "768065119425-hg10t0osvjqrt6pne3toaobabn5gobqs.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDDh8PWdeUSvv55vUQsRIO_t23GUukqJAw"
+        },
+        {
+          "current_key": "AIzaSyDpLXffDgRluouKQ54Z4hSPqRORBbTwjcY"
+        },
+        {
+          "current_key": "AIzaSyDx6neJf_c4NA_17mNZ9e_aD4-SGJyig8c"
+        },
+        {
+          "current_key": "AIzaSyC29AadllbS3sZ3Jq_72Ae-wQaN8ykEx3g"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "768065119425-05thotts3f4ujdcscoaeheebpia8ag9m.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      },
+      "admob_app_id": "ca-app-pub-8038725004530429~6936123198"
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:768065119425:android:caa6bc665dc6c381",
+        "android_client_info": {
+          "package_name": "org.commcare.consumerapps.womenshealthhindi"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "768065119425-hg10t0osvjqrt6pne3toaobabn5gobqs.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDDh8PWdeUSvv55vUQsRIO_t23GUukqJAw"
+        },
+        {
+          "current_key": "AIzaSyDpLXffDgRluouKQ54Z4hSPqRORBbTwjcY"
+        },
+        {
+          "current_key": "AIzaSyDx6neJf_c4NA_17mNZ9e_aD4-SGJyig8c"
+        },
+        {
+          "current_key": "AIzaSyC29AadllbS3sZ3Jq_72Ae-wQaN8ykEx3g"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "768065119425-05thotts3f4ujdcscoaeheebpia8ag9m.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      },
+      "admob_app_id": "ca-app-pub-8038725004530429~4284559995"
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:768065119425:android:bf4b2396fb9805b2",
+        "android_client_info": {
+          "package_name": "org.commcare.dalvik"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "768065119425-hg10t0osvjqrt6pne3toaobabn5gobqs.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDDh8PWdeUSvv55vUQsRIO_t23GUukqJAw"
+        },
+        {
+          "current_key": "AIzaSyDpLXffDgRluouKQ54Z4hSPqRORBbTwjcY"
+        },
+        {
+          "current_key": "AIzaSyDx6neJf_c4NA_17mNZ9e_aD4-SGJyig8c"
+        },
+        {
+          "current_key": "AIzaSyC29AadllbS3sZ3Jq_72Ae-wQaN8ykEx3g"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "768065119425-05thotts3f4ujdcscoaeheebpia8ag9m.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:768065119425:android:4e058a2bb3994794",
+        "android_client_info": {
+          "package_name": "org.commcare.dalvik.debug"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "768065119425-hg10t0osvjqrt6pne3toaobabn5gobqs.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDDh8PWdeUSvv55vUQsRIO_t23GUukqJAw"
+        },
+        {
+          "current_key": "AIzaSyDpLXffDgRluouKQ54Z4hSPqRORBbTwjcY"
+        },
+        {
+          "current_key": "AIzaSyDx6neJf_c4NA_17mNZ9e_aD4-SGJyig8c"
+        },
+        {
+          "current_key": "AIzaSyC29AadllbS3sZ3Jq_72Ae-wQaN8ykEx3g"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "768065119425-05thotts3f4ujdcscoaeheebpia8ag9m.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:768065119425:android:fb0dc29d6fbc17992fa040",
+        "android_client_info": {
+          "package_name": "org.commcare.dalvik.reminders"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "768065119425-hg10t0osvjqrt6pne3toaobabn5gobqs.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDDh8PWdeUSvv55vUQsRIO_t23GUukqJAw"
+        },
+        {
+          "current_key": "AIzaSyDpLXffDgRluouKQ54Z4hSPqRORBbTwjcY"
+        },
+        {
+          "current_key": "AIzaSyDx6neJf_c4NA_17mNZ9e_aD4-SGJyig8c"
+        },
+        {
+          "current_key": "AIzaSyC29AadllbS3sZ3Jq_72Ae-wQaN8ykEx3g"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "768065119425-05thotts3f4ujdcscoaeheebpia8ag9m.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:768065119425:android:e07510ddb3459ee3",
+        "android_client_info": {
+          "package_name": "org.commcare.lts"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "768065119425-hg10t0osvjqrt6pne3toaobabn5gobqs.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDDh8PWdeUSvv55vUQsRIO_t23GUukqJAw"
+        },
+        {
+          "current_key": "AIzaSyDpLXffDgRluouKQ54Z4hSPqRORBbTwjcY"
+        },
+        {
+          "current_key": "AIzaSyDx6neJf_c4NA_17mNZ9e_aD4-SGJyig8c"
+        },
+        {
+          "current_key": "AIzaSyC29AadllbS3sZ3Jq_72Ae-wQaN8ykEx3g"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "768065119425-05thotts3f4ujdcscoaeheebpia8ag9m.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:768065119425:android:13a443baea08b29e",
+        "android_client_info": {
+          "package_name": "org.commcare.lts.debug"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "768065119425-hg10t0osvjqrt6pne3toaobabn5gobqs.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDDh8PWdeUSvv55vUQsRIO_t23GUukqJAw"
+        },
+        {
+          "current_key": "AIzaSyDpLXffDgRluouKQ54Z4hSPqRORBbTwjcY"
+        },
+        {
+          "current_key": "AIzaSyDx6neJf_c4NA_17mNZ9e_aD4-SGJyig8c"
+        },
+        {
+          "current_key": "AIzaSyC29AadllbS3sZ3Jq_72Ae-wQaN8ykEx3g"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "768065119425-05thotts3f4ujdcscoaeheebpia8ag9m.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:768065119425:android:842c1a672963e7052fa040",
         "android_client_info": {
           "package_name": "richard.chard.lu.android.areamapper"
         }
       },
       "oauth_client": [
         {
-          "client_id": "363835147397-o7m4tvjb3dmnugun511gcjohqae4isof.apps.googleusercontent.com",
-          "client_type": 1,
-          "android_info": {
-            "package_name": "richard.chard.lu.android.areamapper",
-            "certificate_hash": "b170b8c2d0571d502c869cf81862d7be1019db26"
-          }
-        },
-        {
-          "client_id": "363835147397-t85mfsavpsogn159gpohiekvc18jb1m2.apps.googleusercontent.com",
+          "client_id": "768065119425-hg10t0osvjqrt6pne3toaobabn5gobqs.apps.googleusercontent.com",
           "client_type": 3
         }
       ],
       "api_key": [
         {
-          "current_key": "@apiKey@"
+          "current_key": "AIzaSyDDh8PWdeUSvv55vUQsRIO_t23GUukqJAw"
+        },
+        {
+          "current_key": "AIzaSyDpLXffDgRluouKQ54Z4hSPqRORBbTwjcY"
+        },
+        {
+          "current_key": "AIzaSyDx6neJf_c4NA_17mNZ9e_aD4-SGJyig8c"
+        },
+        {
+          "current_key": "AIzaSyC29AadllbS3sZ3Jq_72Ae-wQaN8ykEx3g"
         }
       ],
       "services": {
-        "analytics_service": {
-          "status": 1
-        },
         "appinvite_service": {
-          "status": 2,
           "other_platform_oauth_client": [
             {
-              "client_id": "363835147397-t85mfsavpsogn159gpohiekvc18jb1m2.apps.googleusercontent.com",
+              "client_id": "768065119425-05thotts3f4ujdcscoaeheebpia8ag9m.apps.googleusercontent.com",
               "client_type": 3
             }
           ]
-        },
-        "ads_service": {
-          "status": 2
         }
       }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
         classpath 'com.google.gms:google-services:4.3.10'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.8.1'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,7 @@ buildscript {
     repositories {
         mavenCentral()
         google()
-        maven {
-            url 'https://maven.fabric.io/public'
-        }
+
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.1.0'
@@ -14,7 +12,6 @@ buildscript {
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
         classpath 'com.google.gms:google-services:4.3.10'
-        classpath 'io.fabric.tools:gradle:1.28.1'
     }
 }
 


### PR DESCRIPTION
This PR moves the app away from deprecated Fabric sdk to Firebase sdk. A crash simulation followed the last commit and it was successful, the resulting log can be found [here](https://console.firebase.google.com/u/1/project/commcare-a57e4/crashlytics/app/android:richard.chard.lu.android.areamapper/issues/89dd0e1be48337c304855fb164d26d9c?time=last-seven-days&sessionEventKey=62855CBA02EB00010DEFCD2A7B6C4C54_1677628091210261686).

Note: This PR replaces PR #12, which had already been approved, however because it was branched off of another branch that was renamed and amended, it was rebased and so the previous PR closed.