### PR TITLE
Shift to the new renderer of the Maps SDK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-maps:18.0.2'
     implementation 'com.google.android.gms:play-services-location:19.0.1'
     implementation 'com.google.maps.android:android-maps-utils:0.3.4'
-    implementation 'com.google.firebase:firebase-core:16.0.5'
+    implementation 'com.google.firebase:firebase-analytics:18.0.3'
     implementation 'com.google.firebase:firebase-crashlytics:17.4.1'
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,7 +35,7 @@ android {
     defaultConfig {
         applicationId "richard.chard.lu.android.areamapper"
         signingConfig signingConfigs.release
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 31
         versionCode 5
         versionName "5.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,8 +63,8 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.0.0'
-    implementation 'com.google.android.gms:play-services-maps:16.0.0'
-    implementation 'com.google.android.gms:play-services-location:16.0.0'
+    implementation 'com.google.android.gms:play-services-maps:18.0.2'
+    implementation 'com.google.android.gms:play-services-location:19.0.1'
     implementation 'com.google.maps.android:android-maps-utils:0.3.4'
     implementation 'com.google.firebase:firebase-core:16.0.5'
     implementation 'com.google.firebase:firebase-crashlytics:17.4.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.0'
     implementation 'com.google.android.gms:play-services-maps:18.0.2'
     implementation 'com.google.android.gms:play-services-location:19.0.1'
-    implementation 'com.google.maps.android:android-maps-utils:0.3.4'
+    implementation 'com.google.maps.android:android-maps-utils:2.3.0'
     implementation 'com.google.firebase:firebase-analytics:18.0.3'
     implementation 'com.google.firebase:firebase-crashlytics:17.4.1'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
         android:allowBackup="true"
         android:icon="@drawable/icon"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme" >
+        android:theme="@style/AppTheme"
+        android:name=".AreaMapperApplication">
         <activity
             android:name=".activities.BaseActivity"
             android:configChanges="orientation|screenSize|keyboardHidden"

--- a/app/src/main/java/richard/chard/lu/android/areamapper/AreaMapperApplication.java
+++ b/app/src/main/java/richard/chard/lu/android/areamapper/AreaMapperApplication.java
@@ -2,10 +2,14 @@ package richard.chard.lu.android.areamapper;
 
 import android.app.Application;
 
+import com.google.android.gms.maps.MapsInitializer;
+
 public class AreaMapperApplication extends Application {
 
     @Override
     public void onCreate() {
         super.onCreate();
+
+        MapsInitializer.initialize(getApplicationContext(), MapsInitializer.Renderer.LATEST, null);
     }
 }

--- a/app/src/main/java/richard/chard/lu/android/areamapper/AreaMapperApplication.java
+++ b/app/src/main/java/richard/chard/lu/android/areamapper/AreaMapperApplication.java
@@ -1,0 +1,11 @@
+package richard.chard.lu.android.areamapper;
+
+import android.app.Application;
+
+public class AreaMapperApplication extends Application {
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+    }
+}

--- a/app/src/main/java/richard/chard/lu/android/areamapper/activities/AreaMapperActivity.java
+++ b/app/src/main/java/richard/chard/lu/android/areamapper/activities/AreaMapperActivity.java
@@ -35,7 +35,6 @@ import com.google.android.gms.location.LocationServices;
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.MapView;
-import com.google.android.gms.maps.MapsInitializer;
 import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.Polygon;
@@ -682,8 +681,6 @@ public class AreaMapperActivity extends AppCompatActivity
     @Override
     public void onMapReady(GoogleMap map) {
         LOG.trace("Entry");
-
-        MapsInitializer.initialize(getApplicationContext());
 
         this.map = map;
 

--- a/app/src/main/java/richard/chard/lu/android/areamapper/activities/BaseActivity.java
+++ b/app/src/main/java/richard/chard/lu/android/areamapper/activities/BaseActivity.java
@@ -14,7 +14,7 @@ import com.google.android.gms.maps.OnMapsSdkInitializedCallback;
 import richard.chard.lu.android.areamapper.Logger;
 import richard.chard.lu.android.areamapper.ResultCode;
 
-public class BaseActivity extends AppCompatActivity implements OnMapsSdkInitializedCallback {
+public class BaseActivity extends AppCompatActivity {
 
     private static final Logger LOG = Logger.create(BaseActivity.class);
 
@@ -69,6 +69,9 @@ public class BaseActivity extends AppCompatActivity implements OnMapsSdkInitiali
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         LOG.trace("Entry");
+
+        MapsInitializer.initialize(getApplicationContext(), Renderer.LATEST, null);
+
         super.onCreate(savedInstanceState);
 
         startAreaMapperActivity();
@@ -92,15 +95,5 @@ public class BaseActivity extends AppCompatActivity implements OnMapsSdkInitiali
         LOG.trace("Exit");
     }
 
-    @Override
-    public void onMapsSdkInitialized(@NonNull Renderer renderer) {
-        switch (renderer) {
-            case LATEST:
-                Log.d("MapsRenderer", "The latest version of the renderer is used.");
-                break;
-            case LEGACY:
-                Log.d("MapsRenderer", "The legacy version of the renderer is used.");
-                break;
-        }
-    }
+
 }

--- a/app/src/main/java/richard/chard/lu/android/areamapper/activities/BaseActivity.java
+++ b/app/src/main/java/richard/chard/lu/android/areamapper/activities/BaseActivity.java
@@ -2,15 +2,19 @@ package richard.chard.lu.android.areamapper.activities;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.google.android.gms.maps.MapsInitializer;
 import com.google.android.gms.maps.MapsInitializer.Renderer;
+import com.google.android.gms.maps.OnMapsSdkInitializedCallback;
 
 import richard.chard.lu.android.areamapper.Logger;
 import richard.chard.lu.android.areamapper.ResultCode;
 
-public class BaseActivity extends AppCompatActivity {
+public class BaseActivity extends AppCompatActivity implements OnMapsSdkInitializedCallback {
 
     private static final Logger LOG = Logger.create(BaseActivity.class);
 
@@ -86,5 +90,17 @@ public class BaseActivity extends AppCompatActivity {
         );
 
         LOG.trace("Exit");
+    }
+
+    @Override
+    public void onMapsSdkInitialized(@NonNull Renderer renderer) {
+        switch (renderer) {
+            case LATEST:
+                Log.d("MapsRenderer", "The latest version of the renderer is used.");
+                break;
+            case LEGACY:
+                Log.d("MapsRenderer", "The legacy version of the renderer is used.");
+                break;
+        }
     }
 }

--- a/app/src/main/java/richard/chard/lu/android/areamapper/activities/BaseActivity.java
+++ b/app/src/main/java/richard/chard/lu/android/areamapper/activities/BaseActivity.java
@@ -2,14 +2,8 @@ package richard.chard.lu.android.areamapper.activities;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
-
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
-import com.google.android.gms.maps.MapsInitializer;
-import com.google.android.gms.maps.MapsInitializer.Renderer;
-import com.google.android.gms.maps.OnMapsSdkInitializedCallback;
 
 import richard.chard.lu.android.areamapper.Logger;
 import richard.chard.lu.android.areamapper.ResultCode;
@@ -69,9 +63,6 @@ public class BaseActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         LOG.trace("Entry");
-
-        MapsInitializer.initialize(getApplicationContext(), Renderer.LATEST, null);
-
         super.onCreate(savedInstanceState);
 
         startAreaMapperActivity();

--- a/app/src/main/java/richard/chard/lu/android/areamapper/activities/BaseActivity.java
+++ b/app/src/main/java/richard/chard/lu/android/areamapper/activities/BaseActivity.java
@@ -4,6 +4,9 @@ import android.content.Intent;
 import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.google.android.gms.maps.MapsInitializer;
+import com.google.android.gms.maps.MapsInitializer.Renderer;
+
 import richard.chard.lu.android.areamapper.Logger;
 import richard.chard.lu.android.areamapper.ResultCode;
 
@@ -63,6 +66,7 @@ public class BaseActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         LOG.trace("Entry");
         super.onCreate(savedInstanceState);
+
         startAreaMapperActivity();
         LOG.trace("Exit");
     }


### PR DESCRIPTION
This PR introduces the new Renderer of the Maps SDK. The new Renderer brings optimizations that reduce network load, on-device processing, and memory consumption for a more stable and smoother end-user experience. In order to make this possible, a few additional changes were motivated: 
- Minimum Android SDK was bumped to 19 to meet the minimum requirements of the Maps SDK version 18+
- Firebase Core explicit dependency declaration was replaced by Firebase Analytics, the latter is a recommended dependency of Firebase Crashlytics. Firebase Core doesn't need to be declared anymore. 
- Android Utility library was updated to the latest version 2.3.0 

Ticket used to guide this work: [SAAS-13185](https://dimagi-dev.atlassian.net/browse/SAAS-13185)



