### PR TITLE
Implement file provider to share screenshot

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,16 @@
         <meta-data
             android:name="com.google.android.maps.v2.API_KEY"
             android:value="@string/google_maps_api_key"/>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="richard.chard.lu.android.areamapper.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/richard/chard/lu/android/areamapper/SaveImageAsyncTask.java
+++ b/app/src/main/java/richard/chard/lu/android/areamapper/SaveImageAsyncTask.java
@@ -18,7 +18,7 @@ public class SaveImageAsyncTask extends AsyncTask<Void, Void, Void> {
 
     public interface OnImageSavedListener {
 
-        public void onImageSaved(String filePath);
+        public void onImageSaved(File imageFile);
 
     }
 
@@ -31,7 +31,7 @@ public class SaveImageAsyncTask extends AsyncTask<Void, Void, Void> {
     private final String filePrefix;
     private final String fileSuffix;
     private final OnImageSavedListener listener;
-    private String filePath;
+    private File imageFile;
 
     public SaveImageAsyncTask(
             Bitmap bitmap,
@@ -89,7 +89,7 @@ public class SaveImageAsyncTask extends AsyncTask<Void, Void, Void> {
 
         // Write file
 
-        File imageFile = new File(imageFolder, imageFileName);
+        imageFile = new File(imageFolder, imageFileName);
 
         try {
             FileOutputStream fileOutputStream = new FileOutputStream(imageFile);
@@ -99,8 +99,6 @@ public class SaveImageAsyncTask extends AsyncTask<Void, Void, Void> {
             throw new RuntimeException(ioe);
         }
 
-        filePath = imageFile.getPath();
-
         LOG.trace("Exit");
         return null;
     }
@@ -109,7 +107,7 @@ public class SaveImageAsyncTask extends AsyncTask<Void, Void, Void> {
     protected void onPostExecute(Void aVoid) {
         LOG.trace("Entry");
 
-        listener.onImageSaved(filePath);
+        listener.onImageSaved(imageFile);
 
         LOG.trace("Exit");
     }

--- a/app/src/main/java/richard/chard/lu/android/areamapper/SaveImageAsyncTask.java
+++ b/app/src/main/java/richard/chard/lu/android/areamapper/SaveImageAsyncTask.java
@@ -69,12 +69,8 @@ public class SaveImageAsyncTask extends AsyncTask<Void, Void, Void> {
 
         // Check for image folder, create if needed
 
-        File imageFolder = new File(
-                Environment.getExternalStoragePublicDirectory(
-                        Environment.DIRECTORY_PICTURES
-                ),
-                folderName
-        );
+        File imageFolder = new File(folderName);
+
         if (!imageFolder.mkdirs() && !imageFolder.isDirectory()) {
             throw new RuntimeException("Failed to create directory "+imageFolder.getPath());
         }

--- a/app/src/main/java/richard/chard/lu/android/areamapper/activities/AreaMapperActivity.java
+++ b/app/src/main/java/richard/chard/lu/android/areamapper/activities/AreaMapperActivity.java
@@ -5,6 +5,7 @@ import android.animation.ValueAnimator;
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.AlertDialog;
+import android.content.ClipData;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
@@ -499,14 +500,17 @@ public class AreaMapperActivity extends AppCompatActivity
                             areaCalculator.getCoordinatesString()
                     );
                 }
+                Intent data = new Intent();
+
                 if (isImageReturnRequired) {
                     result.putString(
                             EXTRA_KEY_IMAGE,
                             mapSnapshotPath
                     );
-                }
 
-                Intent data = new Intent();
+                    data.setClipData(ClipData.newRawUri("", contentUri));
+                    data.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                }
 
                 data.putExtra(INTENT_RESULT, Double.toString(areaCalculator.getArea()));
 

--- a/app/src/main/java/richard/chard/lu/android/areamapper/activities/AreaMapperActivity.java
+++ b/app/src/main/java/richard/chard/lu/android/areamapper/activities/AreaMapperActivity.java
@@ -17,12 +17,6 @@ import android.location.LocationManager;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.core.app.ActivityCompat;
-import androidx.core.content.ContextCompat;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.content.FileProvider;
-
 import android.os.Environment;
 import android.view.View;
 import android.widget.HorizontalScrollView;
@@ -31,6 +25,12 @@ import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.SeekBar;
 import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
+import androidx.core.content.FileProvider;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.api.GoogleApiClient;
@@ -46,7 +46,6 @@ import com.google.android.gms.maps.model.Polygon;
 import com.google.android.gms.maps.model.PolygonOptions;
 
 import java.io.File;
-import java.nio.file.Path;
 
 import richard.chard.lu.android.areamapper.AreaCalculator;
 import richard.chard.lu.android.areamapper.Logger;
@@ -806,13 +805,19 @@ public class AreaMapperActivity extends AppCompatActivity
                 snapshot,
                 Bitmap.CompressFormat.PNG,
                 100,
-                getApplicationContext().getExternalFilesDir(Environment.DIRECTORY_PICTURES).getPath() + File.separator + IMAGE_FILE_FOLDER,
+                getImageFolder(),
                 IMAGE_FILE_PREFIX,
                 IMAGE_FILE_SUFFIX,
                 this
         ).execute();
 
         LOG.trace("Exit");
+    }
+
+    // Returns the absolute path of the folder where the screenshot should be stored
+    // The parent folder is the application's directory in the external storage where it can securely store its files
+    private String getImageFolder() {
+        return getApplicationContext().getExternalFilesDir(Environment.DIRECTORY_PICTURES).getPath() + File.separator + IMAGE_FILE_FOLDER;
     }
 
     @Override

--- a/app/src/main/java/richard/chard/lu/android/areamapper/activities/AreaMapperActivity.java
+++ b/app/src/main/java/richard/chard/lu/android/areamapper/activities/AreaMapperActivity.java
@@ -19,6 +19,8 @@ import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.appcompat.app.AppCompatActivity;
+
+import android.os.Environment;
 import android.view.View;
 import android.widget.HorizontalScrollView;
 import android.widget.ImageButton;
@@ -39,6 +41,9 @@ import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.Polygon;
 import com.google.android.gms.maps.model.PolygonOptions;
+
+import java.io.File;
+import java.nio.file.Path;
 
 import richard.chard.lu.android.areamapper.AreaCalculator;
 import richard.chard.lu.android.areamapper.Logger;
@@ -790,7 +795,7 @@ public class AreaMapperActivity extends AppCompatActivity
                 snapshot,
                 Bitmap.CompressFormat.PNG,
                 100,
-                IMAGE_FILE_FOLDER,
+                getApplicationContext().getExternalFilesDir(Environment.DIRECTORY_PICTURES).getPath() + File.separator + IMAGE_FILE_FOLDER,
                 IMAGE_FILE_PREFIX,
                 IMAGE_FILE_SUFFIX,
                 this

--- a/app/src/main/java/richard/chard/lu/android/areamapper/activities/AreaMapperActivity.java
+++ b/app/src/main/java/richard/chard/lu/android/areamapper/activities/AreaMapperActivity.java
@@ -13,12 +13,14 @@ import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.location.Location;
 import android.location.LocationManager;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.FileProvider;
 
 import android.os.Environment;
 import android.view.View;
@@ -81,6 +83,7 @@ public class AreaMapperActivity extends AppCompatActivity
     private static final String IMAGE_FILE_FOLDER = "AreaMapperImages";
     private static final String IMAGE_FILE_PREFIX = "map_image-";
     private static final String IMAGE_FILE_SUFFIX = ".png";
+    private static final String IMAGE_PROVIDER_AUTHORITY = "richard.chard.lu.android.areamapper.fileprovider";
 
     private static final int LOCATION_MIN_MAX_ACCURACY = 50;
     private static final int LOCATION_MIN_MIN_ACCURACY = 10;
@@ -91,7 +94,6 @@ public class AreaMapperActivity extends AppCompatActivity
 
     private static final float MAP_SCROLL_PX = 150;
     private static final int REQUEST_CODE_LOCATION_PERMISSION = 1001;
-
 
     private ValueAnimator settingsMenuAnimator = ValueAnimator.ofFloat(0f, 1f);
 
@@ -119,6 +121,8 @@ public class AreaMapperActivity extends AppCompatActivity
     private MapView mapView;
 
     private Location previousLocation;
+
+    private Uri contentUri;
 
     private int recordingIntervalMeters = 0;
     private int recordingIntervalMillis = 0;
@@ -629,9 +633,12 @@ public class AreaMapperActivity extends AppCompatActivity
     }
 
     @Override
-    public void onImageSaved(String filePath) {
-        LOG.trace("Entry, filePath={}", filePath);
-        mapSnapshotPath = filePath;
+    public void onImageSaved(File imageFile) {
+        LOG.trace("Entry, imageFile={}", imageFile.getPath());
+
+        contentUri = FileProvider.getUriForFile(getApplicationContext(), IMAGE_PROVIDER_AUTHORITY, imageFile);
+
+        mapSnapshotPath = contentUri.toString();
         findViewById(R.id.button_ok).setEnabled(true);
         LOG.trace("Exit");
     }

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,3 @@
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <files-path name="AreaMapperImages" path="."/>
+</paths>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,3 +1,3 @@
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
-    <files-path name="AreaMapperImages" path="."/>
+    <external-files-path name="AreaMapperImages" path="."/>
 </paths>


### PR DESCRIPTION
This PR changes the way the map screenshot is shared with third parties, from direct file path using the shared public directory to a File Provider. This need was motivated by recent changes to the android storage model which led to the introduction of scoped storage, while it made writing to app's own directories easier, access to the external public directory became stricter and no longer recommended. 

Note: The SaveImageAsyncTask class now returns a File object instead of just the path, the file object is required by the File Provider to generate the URI.

 https://dimagi-dev.atlassian.net/browse/SAAS-13203