### PR TITLE
Revert the property key names of the signing key

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,12 +6,12 @@ apply plugin: 'com.google.firebase.crashlytics'
 ext {
     // Obtained from ~/.gradle/gradle.properties on build server (mobile agent), or your local
     // ~/.gradle/gradle.properties file, or loads default empty strings if neither is present
-    RELEASE_STORE_FILE = project.properties['RELEASE_STORE_FILE'] ?: "."
-    RELEASE_STORE_PASSWORD = project.properties['RELEASE_STORE_PASSWORD'] ?: ""
-    RELEASE_KEY_ALIAS = project.properties['RELEASE_KEY_ALIAS'] ?: ""
-    RELEASE_KEY_PASSWORD = project.properties['RELEASE_KEY_PASSWORD'] ?: ""
-    GOOGLE_PLAY_MAPS_API_KEY = project.properties['GOOGLE_PLAY_MAPS_API_KEY'] ?: ""
-    GOOGLE_SERVICES_API_KEY = project.properties['GOOGLE_SERVICES_API_KEY'] ?: ""
+    RELEASE_STORE_FILE = project.properties['AREA_MAPPER_RELEASE_STORE_FILE'] ?: "."
+    RELEASE_STORE_PASSWORD = project.properties['AREA_MAPPER_RELEASE_STORE_PASSWORD'] ?: ""
+    RELEASE_KEY_ALIAS = project.properties['AREA_MAPPER_RELEASE_KEY_ALIAS'] ?: ""
+    RELEASE_KEY_PASSWORD = project.properties['AREA_MAPPER_RELEASE_KEY_PASSWORD'] ?: ""
+    GOOGLE_PLAY_MAPS_API_KEY = project.properties['AREA_MAPPER_GOOGLE_PLAY_MAPS_API_KEY'] ?: ""
+    GOOGLE_SERVICES_API_KEY = project.properties['AREA_MAPPER_GOOGLE_SERVICES_API_KEY'] ?: ""
 }
 
 repositories {


### PR DESCRIPTION
This PR reverts the property key names of the signing key to the previous version. These were changed in a previous effort to consolidate the different keys when we were having trouble with the `keystore`, but the issue was eventually resolved and this was no longer needed.